### PR TITLE
.desktop file autostart not implemented in beta 6 but mentioned in FAQ

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -106,8 +106,6 @@ We're sorry, but we have to prioritize other things for now.
 ## How to I put things in the autostart
 
 InstantOS executes a shell script at `~/.config/instantos/autostart.sh` on startup.
-You can also link or copy a `.desktop` file to `~/.config/autostart` or use a
-graphica tool that does this.
 
 ## Does it support 32 bit
 


### PR DESCRIPTION
`.desktop` files loading from `~/.config/autostart` at startup was implemented after beta 6, thus should not be mentioned on official resources unless flagged as being in master only.